### PR TITLE
PRD-2505 Allow querying for specific secrets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,17 @@
+name: Build Java SDK
+on: [push]
+
+jobs:
+  build-java-sdk:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+      - name: Build with Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: build

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,9 +26,8 @@ java {
 }
 apply(plugin = "org.openapi.generator")
 
-val junitVersion = "4.13.2"
-val mockitoVersion = "3.12.4"
-val powermockVersion = "2.0.9"
+val junitVersion = "5.10.0"
+val mockitoVersion = "5.4.0"
 
 val swaggerAnnotationsVersion = "1.5.22"
 val jacksonVersion = "2.10.5"
@@ -53,17 +52,16 @@ dependencies {
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion")
     implementation("jakarta.annotation:jakarta.annotation-api:$jakartaAnnotationVersion")
 
-    testImplementation("junit:junit:$junitVersion")
-    testImplementation("org.mockito:mockito-inline:$mockitoVersion")
-    testImplementation("org.powermock:powermock-core:$powermockVersion")
-    testImplementation("org.powermock:powermock-api-mockito2:$powermockVersion")
-    testImplementation("org.powermock:powermock-module-junit4:$powermockVersion")
+    testImplementation("org.junit.jupiter:junit-jupiter-api:$junitVersion")
+    testImplementation("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
+
+    testImplementation("org.mockito:mockito-core:$mockitoVersion")
+    testImplementation("org.mockito:mockito-junit-jupiter:$mockitoVersion")
 }
 
 val clientOutputDir = "$buildDir/generated/openapi/default/java-client"
 val clientArtifactId = project.name.toLowerCase().replace(Regex("[^a-z0-9]"), "")
 val clientArtifactVersion = project.version.toString()
-println("project.version: ${project.version}")
 
 tasks.register("generate-http-client", org.openapitools.generator.gradle.plugin.tasks.GenerateTask::class.java) {
     inputSpec.set("$rootDir/specs/openapi.yml")
@@ -124,13 +122,7 @@ tasks.named("assemble").configure {
 }
 
 tasks.withType<Test> {
-    useJUnit()
-    jvmArgs("--add-opens", "java.base/java.lang=ALL-UNNAMED")
-    jvmArgs("--add-opens", "java.base/java.io=ALL-UNNAMED")
-    jvmArgs("--add-opens", "java.net.http/java.net.http=ALL-UNNAMED")
-    jvmArgs("--add-opens", "java.net.http/jdk.internal.net.http=ALL-UNNAMED")
-    jvmArgs("--add-opens", "java.base/java.util.concurrent=ALL-UNNAMED")
-    jvmArgs("--add-opens", "java.base/java.util=ALL-UNNAMED")
+    useJUnitPlatform()
 }
 
 tasks.withType<Javadoc>() {

--- a/specs/openapi.yml
+++ b/specs/openapi.yml
@@ -14,6 +14,7 @@ paths:
         - $ref: "#/components/parameters/CatalogAppId"
         - $ref: "#/components/parameters/EnvironmentIdQueryParam"
         - $ref: "#/components/parameters/RenderingModeParam"
+        - $ref: "#/components/parameters/SecretNameFilter"
       responses:
         "200":
           description: Rendered secrets for the app in the requested environment
@@ -86,6 +87,15 @@ components:
         type: string
       description: UUID of the item after which the items are needed (for supporting
         the next use-case)
+    SecretNameFilter:
+      in: query
+      name: secret-name-filter
+      required: false
+      schema:
+        type: array
+        items:
+          type: string
+      description: Secret names to return values for
   schemas:
     RenderedAppSecretsResponse:
       allOf:

--- a/src/main/java/dev/commandk/javasdk/CommandKClient.java
+++ b/src/main/java/dev/commandk/javasdk/CommandKClient.java
@@ -11,16 +11,17 @@ import dev.commandk.javasdk.exception.ResponseNotModifiedException;
 import dev.commandk.javasdk.kvstore.GlobalKVStoreFactory;
 import dev.commandk.javasdk.kvstore.KVStore;
 import dev.commandk.javasdk.kvstore.KVStoreFactory;
-import dev.commandk.javasdk.models.EnvironmentDescriptor;
-import dev.commandk.javasdk.models.GetAllEnvironmentsResponse;
-import dev.commandk.javasdk.models.RenderedAppSecret;
-import dev.commandk.javasdk.models.RenderedAppSecretsResponse;
-import dev.commandk.javasdk.models.RenderingMode;
+import dev.commandk.javasdk.models.*;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestTemplate;
 
 import javax.annotation.Nonnull;
-import java.util.*;
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static java.util.Collections.emptyList;
 
 class CommandKResponse {
 
@@ -88,8 +89,9 @@ public class CommandKClient {
 
 
     public @Nonnull List<RenderedAppSecret> getRenderedAppSecrets(
-        @Nonnull String catalogAppId,
-        @Nonnull String environment
+            @Nonnull String catalogAppId,
+            @Nonnull String environment,
+            @Nullable List<String> secretNames
     ) {
 
         Optional<EnvironmentDescriptor> environmentDescriptor = getEnvironments().stream().filter( it ->
@@ -109,8 +111,9 @@ public class CommandKClient {
         String ifNoneMatch = commandKResponseOptional.map(CommandKResponse::getETag).orElse("");
 
         try{
+            List<String> secretNamesToQuery = secretNames != null ? secretNames : emptyList();
             ResponseEntity<RenderedAppSecretsResponse> renderedAppSecretsWithHttpInfo =
-                    sdkApi.getRenderedAppSecretsWithHttpInfo(catalogAppId, environmentId, RenderingMode.FULL, ifNoneMatch);
+                    sdkApi.getRenderedAppSecretsWithHttpInfo(catalogAppId, environmentId, RenderingMode.FULL, ifNoneMatch, secretNamesToQuery);
 
             List<RenderedAppSecret> renderedAppSecrets = renderedAppSecretsWithHttpInfo.getBody().getSecrets();
 

--- a/src/test/java/dev/commandk/javasdk/CommandKClientTest.java
+++ b/src/test/java/dev/commandk/javasdk/CommandKClientTest.java
@@ -9,54 +9,53 @@ import dev.commandk.javasdk.exception.ConfigException;
 import dev.commandk.javasdk.exception.ResponseNotModifiedException;
 import dev.commandk.javasdk.kvstore.KVStore;
 import dev.commandk.javasdk.kvstore.KVStoreFactory;
-import dev.commandk.javasdk.models.RenderedAppSecret;
-import dev.commandk.javasdk.models.RenderedAppSecretValueType;
-import dev.commandk.javasdk.models.RenderedAppSecretsResponse;
-import dev.commandk.javasdk.models.RenderingMode;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import dev.commandk.javasdk.models.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.platform.commons.util.ReflectionUtils;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
-
-import java.util.*;
-
-import org.powermock.api.mockito.PowerMockito;
-
-import static org.mockito.Mockito.*;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.client.RestTemplate;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({CommandKClient.class, RestTemplate.class})
+import java.lang.reflect.Field;
+import java.util.*;
+
+import static java.util.Collections.emptyList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
 public class CommandKClientTest {
-    @Captor
-    ArgumentCaptor<CommandKResponse> commandKResponseArgumentCaptor;
 
     @Test
     public void CommandKClientTest_nullCredentialProviderAndNullKVStoreFactory_throwException() {
-        Assert.assertThrows(IllegalArgumentException.class, () -> { new CommandKClient(null, null); });
+        assertThrows(IllegalArgumentException.class, () -> {
+            new CommandKClient(null, null);
+        });
     }
 
     @Test
     public void CommandKClientTest_nullCredentialProvider_throwException() {
         KVStoreFactory kvStoreFactoryMock = mock(KVStoreFactory.class);
-        KVStore kvStoreMock = mock(KVStore.class);
-        when(kvStoreFactoryMock.getStore()).thenReturn(kvStoreMock);
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> { new CommandKClient(kvStoreFactoryMock, null); });
+        assertThrows(IllegalArgumentException.class, () -> {
+            new CommandKClient(kvStoreFactoryMock, null);
+        });
     }
 
     @Test
     public void CommandKClientTest_nullKVStoreFactory_throwException() {
         CommandKCredentialsProvider commandKCredentialsProviderMock = mock(CommandKCredentialsProvider.class);
-        when(commandKCredentialsProviderMock.resolveCredentials()).thenReturn(new CommandKCredentials("null", null));
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> { new CommandKClient(null, commandKCredentialsProviderMock); });
+        assertThrows(IllegalArgumentException.class, () -> {
+            new CommandKClient(null, commandKCredentialsProviderMock);
+        });
     }
 
     @Test
@@ -65,10 +64,10 @@ public class CommandKClientTest {
         when(commandKCredentialsProviderMock.resolveCredentials()).thenReturn(null);
 
         KVStoreFactory kvStoreFactoryMock = mock(KVStoreFactory.class);
-        KVStore kvStoreMock = mock(KVStore.class);
-        when(kvStoreFactoryMock.getStore()).thenReturn(kvStoreMock);
 
-        Assert.assertThrows(ConfigException.class, () -> { new CommandKClient(kvStoreFactoryMock, commandKCredentialsProviderMock); });
+        assertThrows(ConfigException.class, () -> {
+            new CommandKClient(kvStoreFactoryMock, commandKCredentialsProviderMock);
+        });
     }
 
     @Test
@@ -77,10 +76,10 @@ public class CommandKClientTest {
         when(commandKCredentialsProviderMock.resolveCredentials()).thenReturn(new CommandKCredentials(null, null));
 
         KVStoreFactory kvStoreFactoryMock = mock(KVStoreFactory.class);
-        KVStore kvStoreMock = mock(KVStore.class);
-        when(kvStoreFactoryMock.getStore()).thenReturn(kvStoreMock);
 
-        Assert.assertThrows(ConfigException.class, () -> { new CommandKClient(kvStoreFactoryMock, commandKCredentialsProviderMock); });
+        assertThrows(ConfigException.class, () -> {
+            new CommandKClient(kvStoreFactoryMock, commandKCredentialsProviderMock);
+        });
     }
 
     @Test
@@ -89,10 +88,10 @@ public class CommandKClientTest {
         when(commandKCredentialsProviderMock.resolveCredentials()).thenReturn(new CommandKCredentials("null", null));
 
         KVStoreFactory kvStoreFactoryMock = mock(KVStoreFactory.class);
-        KVStore kvStoreMock = mock(KVStore.class);
-        when(kvStoreFactoryMock.getStore()).thenReturn(kvStoreMock);
 
-        Assert.assertThrows(ConfigException.class, () -> { new CommandKClient(kvStoreFactoryMock, commandKCredentialsProviderMock); });
+        assertThrows(ConfigException.class, () -> {
+            new CommandKClient(kvStoreFactoryMock, commandKCredentialsProviderMock);
+        });
     }
 
     @Test
@@ -101,10 +100,10 @@ public class CommandKClientTest {
         when(commandKCredentialsProviderMock.resolveCredentials()).thenReturn(new CommandKCredentials(null, "null"));
 
         KVStoreFactory kvStoreFactoryMock = mock(KVStoreFactory.class);
-        KVStore kvStoreMock = mock(KVStore.class);
-        when(kvStoreFactoryMock.getStore()).thenReturn(kvStoreMock);
 
-        Assert.assertThrows(ConfigException.class, () -> { new CommandKClient(kvStoreFactoryMock, commandKCredentialsProviderMock); });
+        assertThrows(ConfigException.class, () -> {
+            new CommandKClient(kvStoreFactoryMock, commandKCredentialsProviderMock);
+        });
     }
 
     @Test
@@ -115,123 +114,160 @@ public class CommandKClientTest {
         KVStoreFactory kvStoreFactoryMock = mock(KVStoreFactory.class);
         when(kvStoreFactoryMock.getStore()).thenReturn(null);
 
-        Assert.assertThrows(ConfigException.class, () -> { new CommandKClient(kvStoreFactoryMock, commandKCredentialsProviderMock); });
-    }
-
-    @Test
-    public void getRenderedAppSecrets_whenEtagNotPresentAndApiReturnsEtagAndAppSecrets_returnAppSecretsAndStoreResponse() throws Exception {
-
-        // Setup
-        String catalogAppId = "catalogAppId";
-        String environment = "environment";
-        String returnedEtag = "etag";
-        RenderedAppSecret returnedRenderedAppSecret = new RenderedAppSecret().key("key")
-                .serializedValue("serializedValue").secretId("secretId")
-                .valueType(RenderedAppSecretValueType.STRING);
-        List<RenderedAppSecret> returnedRenderedAppSecrets = new ArrayList<RenderedAppSecret>() {{ add(returnedRenderedAppSecret); }};
-        GetRenderedAppSecretsRequest getRenderedAppSecretsRequest = new GetRenderedAppSecretsRequest(catalogAppId, environment);
-
-        KVStore<Object, CommandKResponse> kvStoreMock = mock(KVStore.class);
-        when(kvStoreMock.get(any(Object.class))).thenReturn(Optional.empty());
-        KVStoreFactory<Object, CommandKResponse> kvStoreFactoryMock = mock(KVStoreFactory.class);
-        when(kvStoreFactoryMock.getStore()).thenReturn(kvStoreMock);
-
-        CommandKCredentialsProvider commandKCredentialsProviderMock = mock(CommandKCredentialsProvider.class);
-        when(commandKCredentialsProviderMock.resolveCredentials()).thenReturn(new CommandKCredentials("", ""));
-
-        SdkApi sdkApiMock = mock(SdkApi.class);
-        when(sdkApiMock.getRenderedAppSecretsWithHttpInfo(anyString(), anyString(), any(), anyString()))
-                .thenReturn(new ResponseEntity<>(new RenderedAppSecretsResponse().secrets(returnedRenderedAppSecrets), new HttpHeaders(){{add(Headers.E_TAG, returnedEtag);}}, HttpStatus.OK));
-        PowerMockito.whenNew(SdkApi.class).withAnyArguments().thenReturn(sdkApiMock);
-
-        PowerMockito.whenNew(RestTemplate.class).withAnyArguments().thenReturn(mock(RestTemplate.class));
-
-        // Test
-        CommandKClient commandKClient = new CommandKClient(kvStoreFactoryMock, commandKCredentialsProviderMock);
-        List<RenderedAppSecret> renderedAppSecrets = commandKClient.getRenderedAppSecrets(catalogAppId, environment);
-
-        Assert.assertEquals(renderedAppSecrets.size(), returnedRenderedAppSecrets.size());
-        Assert.assertEquals(renderedAppSecrets.get(0), returnedRenderedAppSecret);
-
-        verify(sdkApiMock).getRenderedAppSecretsWithHttpInfo(catalogAppId, environment, RenderingMode.FULL, "");
-        verify(kvStoreMock).get(getRenderedAppSecretsRequest);
-
-        verify(kvStoreMock).set(eq(getRenderedAppSecretsRequest), commandKResponseArgumentCaptor.capture());
-        CommandKResponse commandKResponse = commandKResponseArgumentCaptor.getValue();
-        List<RenderedAppSecret> cachedRenderedAppSecrets = (List<RenderedAppSecret>) commandKResponse.getResponse();
-        Assert.assertEquals(cachedRenderedAppSecrets.size(), returnedRenderedAppSecrets.size());
-        Assert.assertEquals(cachedRenderedAppSecrets.get(0), returnedRenderedAppSecret);
-    }
-
-    @Test
-    public void getRenderedAppSecrets_whenEtagPresentAndApiReturns304_returnCachedResponse() throws Exception{
-
-        // Setup
-        String catalogAppId = "catalogAppId";
-        String environment = "environment";
-        String cachedEtag = "etag";
-        RenderedAppSecret cachedRenderedAppSecret = new RenderedAppSecret().key("key")
-                .serializedValue("serializedValue").secretId("secretId")
-                .valueType(RenderedAppSecretValueType.STRING);
-        List<RenderedAppSecret> cachedRenderedAppSecrets = new ArrayList<RenderedAppSecret>() {{ add(cachedRenderedAppSecret); }};
-        GetRenderedAppSecretsRequest getRenderedAppSecretsRequest = new GetRenderedAppSecretsRequest(catalogAppId, environment);
-
-        KVStore<Object, CommandKResponse> kvStoreMock = mock(KVStore.class);
-        when(kvStoreMock.get(any(Object.class))).thenReturn(Optional.of(new CommandKResponse(cachedEtag, cachedRenderedAppSecrets)));
-        KVStoreFactory<Object, CommandKResponse> kvStoreFactoryMock = mock(KVStoreFactory.class);
-        when(kvStoreFactoryMock.getStore()).thenReturn(kvStoreMock);
-
-        CommandKCredentialsProvider commandKCredentialsProviderMock = mock(CommandKCredentialsProvider.class);
-        when(commandKCredentialsProviderMock.resolveCredentials()).thenReturn(new CommandKCredentials("", ""));
-
-        SdkApi sdkApiMock = mock(SdkApi.class);
-        when(sdkApiMock.getRenderedAppSecretsWithHttpInfo(anyString(), anyString(), any(), anyString()))
-                .thenThrow(new ResponseNotModifiedException());
-        PowerMockito.whenNew(SdkApi.class).withAnyArguments().thenReturn(sdkApiMock);
-        PowerMockito.whenNew(RestTemplate.class).withAnyArguments().thenReturn(mock(RestTemplate.class));
-
-        // Test
-        CommandKClient commandKClient = new CommandKClient(kvStoreFactoryMock, commandKCredentialsProviderMock);
-        List<RenderedAppSecret> renderedAppSecrets = commandKClient.getRenderedAppSecrets(catalogAppId, environment);
-
-        Assert.assertEquals(renderedAppSecrets.size(), cachedRenderedAppSecrets.size());
-        Assert.assertEquals(renderedAppSecrets.get(0), cachedRenderedAppSecret);
-
-        verify(sdkApiMock).getRenderedAppSecretsWithHttpInfo(catalogAppId, environment, RenderingMode.FULL, cachedEtag);
-        verify(kvStoreMock).get(getRenderedAppSecretsRequest);
-    }
-
-    @Test
-    public void getRenderedAppSecrets_whenApiThrowsApiException_clientThrowsClientException() throws Exception {
-
-        // Setup
-        String catalogAppId = "catalogAppId";
-        String environment = "environment";
-        String exceptionMessage = "This is a client exception";
-        GetRenderedAppSecretsRequest getRenderedAppSecretsRequest = new GetRenderedAppSecretsRequest(catalogAppId, environment);
-
-        KVStore<Object, CommandKResponse> kvStoreMock = mock(KVStore.class);
-        when(kvStoreMock.get(any(Object.class))).thenReturn(Optional.empty());
-        KVStoreFactory<Object, CommandKResponse> kvStoreFactoryMock = mock(KVStoreFactory.class);
-        when(kvStoreFactoryMock.getStore()).thenReturn(kvStoreMock);
-
-        CommandKCredentialsProvider commandKCredentialsProviderMock = mock(CommandKCredentialsProvider.class);
-        when(commandKCredentialsProviderMock.resolveCredentials()).thenReturn(new CommandKCredentials("", ""));
-
-        SdkApi sdkApiMock = mock(SdkApi.class);
-        when(sdkApiMock.getRenderedAppSecretsWithHttpInfo(anyString(), anyString(), any(), anyString()))
-                .thenThrow(new ClientException(exceptionMessage));
-        PowerMockito.whenNew(SdkApi.class).withAnyArguments().thenReturn(sdkApiMock);
-        PowerMockito.whenNew(RestTemplate.class).withAnyArguments().thenReturn(mock(RestTemplate.class));
-
-        // Test
-        CommandKClient commandKClient = new CommandKClient(kvStoreFactoryMock, commandKCredentialsProviderMock);
-        ClientException clientException = Assert.assertThrows(ClientException.class, () -> {
-            commandKClient.getRenderedAppSecrets(catalogAppId, environment);
+        assertThrows(ConfigException.class, () -> {
+            new CommandKClient(kvStoreFactoryMock, commandKCredentialsProviderMock);
         });
+    }
 
-        Assert.assertEquals(clientException.getMessage(), exceptionMessage);
-        verify(sdkApiMock).getRenderedAppSecretsWithHttpInfo(catalogAppId, environment, RenderingMode.FULL, "");
-        verify(kvStoreMock).get(getRenderedAppSecretsRequest);
+    @Nested
+    public class RenderedAppSecrets {
+        @Captor
+        ArgumentCaptor<CommandKResponse> commandKResponseArgumentCaptor;
+        String catalogAppId = "catalogAppId";
+        String environmentName = "environment-name";
+        String environmentId = "environment-id";
+        List<EnvironmentDescriptor> environmentDescriptors = Collections.singletonList(new EnvironmentDescriptor().id(environmentId).name(environmentName).slug(environmentName).label("any-label"));
+
+        SdkApi sdkApiMock = mock(SdkApi.class);
+        KVStore<Object, CommandKResponse> kvStoreMock = mock(KVStore.class);
+        KVStoreFactory<Object, CommandKResponse> kvStoreFactoryMock = mock(KVStoreFactory.class);
+
+        CommandKClient commandKClient;
+
+        @BeforeEach
+        public void setup() throws IllegalAccessException {
+            when(sdkApiMock.getEnvironmentsWithHttpInfo(null, null, null)).thenReturn(new ResponseEntity<>(new GetAllEnvironmentsResponse().environments(environmentDescriptors), HttpStatus.OK));
+
+            when(kvStoreMock.get(any(Object.class))).thenReturn(Optional.empty());
+            when(kvStoreFactoryMock.getStore()).thenReturn(kvStoreMock);
+
+            CommandKCredentialsProvider commandKCredentialsProviderMock = mock(CommandKCredentialsProvider.class);
+            when(commandKCredentialsProviderMock.resolveCredentials()).thenReturn(new CommandKCredentials("", ""));
+
+            commandKClient = new CommandKClient(kvStoreFactoryMock, commandKCredentialsProviderMock);
+            // Setting the private field sdkApi in commandKClient to the mock
+            Field field = ReflectionUtils.findFields(CommandKClient.class, f -> f.getName().equals("sdkApi"), ReflectionUtils.HierarchyTraversalMode.TOP_DOWN).get(0);
+            field.setAccessible(true);
+            field.set(commandKClient, sdkApiMock);
+        }
+
+        @Test
+        public void getRenderedAppSecrets_whenEtagNotPresentAndApiReturnsEtagAndAppSecrets_returnAppSecretsAndStoreResponse() throws Exception {
+
+            // Setup
+            String returnedEtag = "etag";
+            RenderedAppSecret returnedRenderedAppSecret = new RenderedAppSecret().key("key").serializedValue("serializedValue").secretId("secretId").valueType(RenderedAppSecretValueType.STRING);
+            List<RenderedAppSecret> returnedRenderedAppSecrets = new ArrayList<RenderedAppSecret>() {{
+                add(returnedRenderedAppSecret);
+            }};
+            GetRenderedAppSecretsRequest getRenderedAppSecretsRequest = new GetRenderedAppSecretsRequest(catalogAppId, environmentId);
+
+            when(sdkApiMock.getRenderedAppSecretsWithHttpInfo(anyString(), anyString(), any(), anyString(), anyList())).thenReturn(new ResponseEntity<>(new RenderedAppSecretsResponse().secrets(returnedRenderedAppSecrets), new HttpHeaders() {{
+                add(Headers.E_TAG, returnedEtag);
+            }}, HttpStatus.OK));
+
+            // Test
+            List<RenderedAppSecret> renderedAppSecrets = commandKClient.getRenderedAppSecrets(catalogAppId, environmentName, null);
+
+            assertEquals(renderedAppSecrets.size(), returnedRenderedAppSecrets.size());
+            assertEquals(renderedAppSecrets.get(0), returnedRenderedAppSecret);
+
+            verify(sdkApiMock).getRenderedAppSecretsWithHttpInfo(catalogAppId, environmentId, RenderingMode.FULL, "", emptyList());
+            verify(kvStoreMock).get(getRenderedAppSecretsRequest);
+
+            verify(kvStoreMock).set(eq(getRenderedAppSecretsRequest), commandKResponseArgumentCaptor.capture());
+            CommandKResponse commandKResponse = commandKResponseArgumentCaptor.getValue();
+            List<RenderedAppSecret> cachedRenderedAppSecrets = (List<RenderedAppSecret>) commandKResponse.getResponse();
+            assertEquals(cachedRenderedAppSecrets.size(), returnedRenderedAppSecrets.size());
+            assertEquals(cachedRenderedAppSecrets.get(0), returnedRenderedAppSecret);
+        }
+
+        @Test
+        public void getRenderedAppSecrets_whenEtagPresentAndApiReturns304_returnCachedResponse() throws Exception {
+
+            // Setup
+            String cachedEtag = "etag";
+            RenderedAppSecret cachedRenderedAppSecret = new RenderedAppSecret().key("key").serializedValue("serializedValue").secretId("secretId").valueType(RenderedAppSecretValueType.STRING);
+            List<RenderedAppSecret> cachedRenderedAppSecrets = new ArrayList<RenderedAppSecret>() {{
+                add(cachedRenderedAppSecret);
+            }};
+            GetRenderedAppSecretsRequest getRenderedAppSecretsRequest = new GetRenderedAppSecretsRequest(catalogAppId, environmentId);
+
+            when(sdkApiMock.getRenderedAppSecretsWithHttpInfo(anyString(), anyString(), any(), anyString(), anyList())).thenThrow(new ResponseNotModifiedException());
+            when(kvStoreMock.get(any(Object.class))).thenReturn(Optional.of(new CommandKResponse(cachedEtag, cachedRenderedAppSecrets)));
+
+            // Test
+            List<RenderedAppSecret> renderedAppSecrets = commandKClient.getRenderedAppSecrets(catalogAppId, environmentName, null);
+
+            assertEquals(renderedAppSecrets.size(), cachedRenderedAppSecrets.size());
+            assertEquals(renderedAppSecrets.get(0), cachedRenderedAppSecret);
+
+            verify(sdkApiMock).getRenderedAppSecretsWithHttpInfo(catalogAppId, environmentId, RenderingMode.FULL, cachedEtag, emptyList());
+            verify(kvStoreMock).get(getRenderedAppSecretsRequest);
+        }
+
+        @Test
+        public void getRenderedAppSecrets_whenApiThrowsApiException_clientThrowsClientException() throws Exception {
+
+            // Setup
+            String exceptionMessage = "This is a client exception";
+            GetRenderedAppSecretsRequest getRenderedAppSecretsRequest = new GetRenderedAppSecretsRequest(catalogAppId, environmentId);
+
+            when(sdkApiMock.getRenderedAppSecretsWithHttpInfo(anyString(), anyString(), any(), anyString(), anyList())).thenThrow(new ClientException(exceptionMessage));
+
+            // Test
+            ClientException clientException = assertThrows(ClientException.class, () -> {
+                commandKClient.getRenderedAppSecrets(catalogAppId, environmentName, null);
+            });
+
+            assertEquals(clientException.getMessage(), exceptionMessage);
+            verify(sdkApiMock).getRenderedAppSecretsWithHttpInfo(catalogAppId, environmentId, RenderingMode.FULL, "", emptyList());
+            verify(kvStoreMock).get(getRenderedAppSecretsRequest);
+        }
+
+
+        @Test
+        public void getRenderedAppSecrets_whenQueryingForSpecificSecrets_returnValuesForOnlyQueriedSecrets() throws Exception {
+
+            // Setup
+            String returnedEtag = "etag";
+            RenderedAppSecret returnedRenderedAppSecret1 = new RenderedAppSecret().key("secret1").serializedValue("serializedValue1").secretId("secret1Id").valueType(RenderedAppSecretValueType.STRING);
+
+            RenderedAppSecret returnedRenderedAppSecret2 = new RenderedAppSecret().key("secret2").serializedValue("serializedValue2").secretId("secret2Id").valueType(RenderedAppSecretValueType.STRING);
+            List<RenderedAppSecret> allRenderedAppSecrets = Arrays.asList(returnedRenderedAppSecret1, returnedRenderedAppSecret2);
+            List<RenderedAppSecret> filteredRenderedAppSecrets = Collections.singletonList(returnedRenderedAppSecret1);
+
+            List<String> secretNameFilter = Collections.singletonList("secret1");
+
+            when(sdkApiMock.getRenderedAppSecretsWithHttpInfo(eq(catalogAppId), eq(environmentId), any(), anyString(), eq(emptyList()))).thenReturn(new ResponseEntity<>(new RenderedAppSecretsResponse().secrets(allRenderedAppSecrets), new HttpHeaders() {{
+                add(Headers.E_TAG, returnedEtag);
+            }}, HttpStatus.OK));
+            when(sdkApiMock.getRenderedAppSecretsWithHttpInfo(eq(catalogAppId), eq(environmentId), any(), anyString(), eq(secretNameFilter))).thenReturn(new ResponseEntity<>(new RenderedAppSecretsResponse().secrets(filteredRenderedAppSecrets), new HttpHeaders() {{
+                add(Headers.E_TAG, returnedEtag);
+            }}, HttpStatus.OK));
+
+            // Test
+
+            // When no secrets are queried, all secrets are returned
+            List<RenderedAppSecret> renderedAppSecrets = commandKClient.getRenderedAppSecrets(catalogAppId, environmentName, null);
+
+            assertEquals(renderedAppSecrets.size(), allRenderedAppSecrets.size());
+
+            Set<RenderedAppSecret> expectedSet = new HashSet<>(allRenderedAppSecrets);
+            Set<RenderedAppSecret> actualSet = new HashSet<>(renderedAppSecrets);
+            assertEquals(expectedSet, actualSet);
+
+            verify(sdkApiMock).getRenderedAppSecretsWithHttpInfo(catalogAppId, environmentId, RenderingMode.FULL, "", emptyList());
+
+            // When secrets are queried, only those secrets are returned
+            renderedAppSecrets = commandKClient.getRenderedAppSecrets(catalogAppId, environmentName, secretNameFilter);
+            assertEquals(renderedAppSecrets.size(), filteredRenderedAppSecrets.size());
+            expectedSet = new HashSet<>(filteredRenderedAppSecrets);
+            actualSet = new HashSet<>(renderedAppSecrets);
+            assertEquals(expectedSet, actualSet);
+
+            verify(sdkApiMock).getRenderedAppSecretsWithHttpInfo(catalogAppId, environmentId, RenderingMode.FULL, "", secretNameFilter);
+        }
+
     }
 }


### PR DESCRIPTION
### Why is the change needed?
The API used by the `java-sdk` now also allows querying for specific secrets. This feature can be extended to the SDK as well.

### What change has been made?
- Updated the model to also include`SecretNameFilter`
- Sending the list of secret names (optionally) when fetching rendered secrets.

**Other Changes:**
- Dependencies on `powermock` have been removed as it was causing errors with JDK 17. The last published version was in 2020.
- Using junit5 instead of junit4 as the dependency on `powermock` is removed (PowerMock is not officially supported by JUnit 5.)
- Updated `mockito` version
- Refactored test cases to also mock environments response
- Added a workflow file for `build` step.

### Any callouts?
Previously the test suite was failing as the response for `getEnvironmentsWithHttpInfo` was not mocked. This has been added under a `@BeforeEach` setup step now.

### Testing
- Verified in a test project that the secrets can be filtered when using the SDK

### Self-Checklist
- [x] The changes are supported by test cases
- [x] The changes have been tested in a dev env
